### PR TITLE
Add page text and visual context

### DIFF
--- a/src/IndexPage.js
+++ b/src/IndexPage.js
@@ -15,6 +15,7 @@ export default class IndexPage extends Component {
       $$('div')
         .addClass('pa3 tr mw-main center')
         .append(
+          $$('h1').append('Hyper Readings').addClass('f1 serif'),
           $$(Button, { text: 'import', icon: 'key', status: 'secondary' }).on('click', () => this.send('hr:import')),
           $$(Button, { text: 'New', icon: 'plus-circle' }).on('click', () => this.send('hr:new'))
         )

--- a/src/IndexPage.js
+++ b/src/IndexPage.js
@@ -15,7 +15,7 @@ export default class IndexPage extends Component {
       $$('div')
         .addClass('pa3 tr mw-main center')
         .append(
-          $$('h1').append('Hyper Readings').addClass('f1 serif'),
+          $$('h1').append('HyperReadings').addClass('f1 serif'),
           $$('p').append('Create and share reading lists with your bestest friends.').addClass('f3 serif'),
           $$(Button, { text: 'import', icon: 'key', status: 'secondary' }).on('click', () => this.send('hr:import')),
           $$(Button, { text: 'New', icon: 'plus-circle' }).on('click', () => this.send('hr:new'))

--- a/src/IndexPage.js
+++ b/src/IndexPage.js
@@ -13,16 +13,20 @@ export default class IndexPage extends Component {
       .ref('list-container')
     el.append(
       $$('div')
-        .addClass('pa3 tr mw-main center')
+        .addClass('mw-main center')
         .append(
-          $$('h1').append('HyperReadings').addClass('f1 serif'),
-          $$('p').append('Create and share reading lists with your bestest friends.').addClass('f3 serif'),
+          $$('h1').append('HyperReadings').addClass('serif pt4 f2'),
+          $$('p').append('Create and share reading lists with your bestest friends.').addClass('f3 mb4 serif')
+        ),
+      $$('div')
+        .addClass('mw-main center tc pb5')
+        .append(
           $$(Button, { text: 'import', icon: 'key', status: 'secondary' }).on('click', () => this.send('hr:import')),
           $$(Button, { text: 'New', icon: 'plus-circle' }).on('click', () => this.send('hr:new'))
         )
     )
     const readings = $$('ul')
-      .addClass('mw-main center')
+      .addClass('mw-main center listOfLists pa0')
       .ref('list')
     if (list && list.length > 0) {
       readings.append(list.map((item, i) => $$(ListItem, item).ref(`list-item-${i}`)))

--- a/src/IndexPage.js
+++ b/src/IndexPage.js
@@ -16,6 +16,7 @@ export default class IndexPage extends Component {
         .addClass('pa3 tr mw-main center')
         .append(
           $$('h1').append('Hyper Readings').addClass('f1 serif'),
+          $$('p').append('Create and share reading lists with your bestest friends.').addClass('f3 serif'),
           $$(Button, { text: 'import', icon: 'key', status: 'secondary' }).on('click', () => this.send('hr:import')),
           $$(Button, { text: 'New', icon: 'plus-circle' }).on('click', () => this.send('hr:new'))
         )

--- a/src/styles/hyper-reader-base.css
+++ b/src/styles/hyper-reader-base.css
@@ -142,4 +142,10 @@
   vertical-align: middle;
 }
 
-.mw-main { max-width: 760px }
+.mw-main {
+  max-width: 600px;
+}
+
+.listOfLists {
+  list-style: none;
+}

--- a/src/ui/components/ListItem.js
+++ b/src/ui/components/ListItem.js
@@ -6,11 +6,11 @@ export default class ListItem extends Component {
     const { key, title, folder, speed, size, hr, authorised } = this.props
     const downloading = size.totalPercentage !== 100
     let el = $$('li')
-      .addClass('pa3')
+      .addClass('pb4')
       .ref('li')
     el.append(
-      $$('div').addClass('sans f6 fw700').append(title || 'untitled'),
-      $$('div').addClass('').append(
+      $$('div').addClass('sans f3 fw700').append(title || 'untitled'),
+      $$('div').addClass('readingList__stats').append(
         $$('span').append('Peers:' + hr.network.connections.length),
         $$('span').append('Upload:' + speed.uploadSpeed),
         $$('span').append('Download:' + speed.downloadSpeed),


### PR DESCRIPTION
This PR makes two significant changes, both intended as first steps to be molded into place.

1. It adds a heading and introduction paragraph to the index page, as an opportunity to explain what the project is. Maybe the heading isn't really needed as the bar on the top is the heading? I'm not sure. But might make sense at the moment to help explain it.
2. It simplifies the layout by making it use vertical spacing only, rather than the current primary and secondary horizontal column layout. We think that this tells a clearer visual story at the moment.

## Before
![screen shot 2018-05-30 at 7 34 40 pm](https://user-images.githubusercontent.com/1239550/40712250-92bca004-6440-11e8-9740-7b805c334e31.png)

## After
![screen shot 2018-05-30 at 7 34 27 pm](https://user-images.githubusercontent.com/1239550/40712263-97639414-6440-11e8-8077-cf55fea69fff.png)
