### PR TITLE
Make the import modal less cramped

### DIFF
--- a/src/HyperReader.js
+++ b/src/HyperReader.js
@@ -51,7 +51,7 @@ export default class HyperReader extends Component {
       'hr:import': () => this.extendState({ 'modal': {
         type: 'import',
         options: {
-          width: 'small',
+          width: 'medium',
           title: 'Import a New Reading List by Key?'
         }
       }}),

--- a/src/editor/components/Modals/ImportByKey.js
+++ b/src/editor/components/Modals/ImportByKey.js
@@ -18,9 +18,11 @@ export default class ImportByKey extends Component {
     })
     form.append(
       $$('p').addClass('mb2').append('Enter the unique key for the reading list you want to import.'),
-      $$(SimpleInput, { label: 'Key', name: 'key', validator: { func: isKey, msg: 'Requires valid key!' } })
-        .ref('input-key'),
-      $$(Button, { text: 'Import', type: 'submit' }),
+      $$('div').addClass('a-flex a-stretch-content a-grow-1 pt3 pb4' ).append(
+        $$(SimpleInput, { label: 'Key',  name: 'key', validator: { func: isKey, msg: 'Requires valid key!' } })
+          .ref('input-key'),
+        $$(Button, { text: 'Import', type: 'submit' }),
+      ),
       $$('p').append('By importing a reading list you are helping to archive it. When Hyper Reader is open you will be helping share this reading list with others.')
     ).ref('form')
     el.append(form).ref('form-container')


### PR DESCRIPTION
Going to import a reading list, I felt like the interface for entering the key was a bit cramped, which made it harder to parse quickly. These commits increase the space, and white-space inside, the modal so that the elements can be grouped in a more intuitive way... I recon 🌮 

## Before

![screen shot 2018-06-02 at 4 37 52 pm](https://user-images.githubusercontent.com/1239550/40871681-8ade74b2-6683-11e8-8185-fecbdb45f37a.png)

## After

![screen shot 2018-06-02 at 4 38 06 pm](https://user-images.githubusercontent.com/1239550/40871684-8e7c6dc2-6683-11e8-9d90-233d68734abc.png)
